### PR TITLE
Eiffel 2.0 components 3PP Version Uplift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.13
+- Upgraded eiffel-remrem-parent version from 0.0.6 to 0.0.7
+
 ## 0.0.12
 - Updated eiffel-remrem-parent version from 0.0.5 to 0.0.6
   Upgraded Jackson.databind.version from 2.9.4 to 2.9.5 in parent 0.0.6 version

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.7</version>
     </parent>
     <artifactId>eiffel-remrem-protocol-interface</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
     <repositories>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
Updated eiffel-remrem-parent version from 0.0.6 to 0.0.7