### PR TITLE
Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.14
+- Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8
+
 ## 0.0.13
 - Upgraded eiffel-remrem-parent version from 0.0.6 to 0.0.7
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.7</version>
+        <version>0.0.8</version>
     </parent>
     <artifactId>eiffel-remrem-protocol-interface</artifactId>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
     <repositories>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
### Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8

Upgraded the jackson databind version as 2.9.5 to  2.9.8
