### PR TITLE
Added lenientValidation support to REMReM generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+- REMReM Generate defination for supported Eiffel protocols updated for support Lenient Validation.
+
 ## 2.0.4
 - Uplifted eiffel-remrem-parent version from 2.0.3 to 2.0.4 to resolve security vulnerability issue.
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0.4</version>
     </parent>
     <artifactId>eiffel-remrem-protocol-interface</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <repositories>
         <repository>
             <id>jitpack.io</id>

--- a/src/main/java/com/ericsson/eiffel/remrem/protocol/MsgService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/protocol/MsgService.java
@@ -30,6 +30,18 @@ public interface MsgService {
      * @return the generated and validate Eiffel messages as json String
      */
     String generateMsg(String msgType, JsonObject jsonMessage);
+    
+    /**
+     * Generate takes a partial message in JSON format, 
+     * validates it and adds mandatory fields before outputting a complete, valid Eiffel message.
+     * lenientValidation will perform the only mandatory field validation and non-mandatory validation failures will place in Eiffel message as a new property(remremGenerateFailures)
+     * 
+     * @param msgType
+     * @param jsonMessage
+     * @param lenientValidation
+     * @return the generated and validate Eiffel messages as json String
+     */
+    String generateMsg(String msgType, JsonObject jsonMessage, Boolean lenientValidation);
 
     /**
      * Returns the Event Id from json formatted eiffel message. 
@@ -73,7 +85,7 @@ public interface MsgService {
      * @param jsonvalidateMessage
      * @return ValidationResult with true if validation is success, if validation fails ValidationResult has false and validation message property's.
      */
-    ValidationResult validateMsg(String msgType, JsonObject jsonvalidateMessage);
+    ValidationResult validateMsg(String msgType, JsonObject jsonvalidateMessage, Boolean lenientValidation);
 
     /**
      * Returns Routing key from the messaging library based on the eiffel message eventType.<br>


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added Lenient Validation support to REMReM Generate, The Lenient Validation will perform the only mandatory field validation and non-mandatory validation failures will place in Eiffel message as a new property(remremGenerateFailures)

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->
The REMReM generate validation will not fail on non-fetal Eiffel message field issues. This feature is an option to the user, the user can decide the enable/disable the Lenient Validation. By default it is disabled.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @raja-maragani 
